### PR TITLE
Solve Python3 SyntaxWarning

### DIFF
--- a/floating_ip.py
+++ b/floating_ip.py
@@ -121,7 +121,7 @@ class FloatingIp(ocf.ResourceAgent):
                 time.sleep( self.rateLimitWait )
             except EnvironmentError: 
                 # Host not found in api
-                if self.failOnHostfindFailure.get() is 'true':
+                if self.failOnHostfindFailure.get() == 'true':
                     raise AbortWithError(ocf.ReturnCodes.isMissconfigured, 'Failed to find server')
                 time.sleep( self.wait )
 
@@ -143,7 +143,7 @@ class FloatingIp(ocf.ResourceAgent):
                 time.sleep( self.rateLimitWait )
             except EnvironmentError: 
                 # Ip not found in api
-                if self.failOnHostfindFailure.get() is 'true':
+                if self.failOnHostfindFailure.get() == 'true':
                     raise AbortWithError(ocf.ReturnCodes.isMissconfigured, 'Failed to find ip')
                 time.sleep( self.wait )
 


### PR DESCRIPTION
Solve `SyntaxWarning: "is" with a literal. Did you mean "=="?`

Explanation for that warning:
https://adamj.eu/tech/2020/01/21/why-does-python-3-8-syntaxwarning-for-is-literal/